### PR TITLE
Simplify withdrawal to Binance only

### DIFF
--- a/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/adapter/Redeem_adapter.java
+++ b/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/adapter/Redeem_adapter.java
@@ -48,7 +48,13 @@ public class Redeem_adapter extends RecyclerView.Adapter<Redeem_adapter.ViewHold
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         final Redeem_model model = historyList.get(position);
-        Glide.with(context).load(model.getImage())
+        Object imgSrc;
+        try {
+            imgSrc = Integer.parseInt(model.getImage());
+        } catch (Exception e) {
+            imgSrc = model.getImage();
+        }
+        Glide.with(context).load(imgSrc)
                 .apply(new RequestOptions().placeholder(R.mipmap.ic_launcher_round))
                 .into(holder.img);
         holder.amount.setText(model.getSymbol()+model.amount);

--- a/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/adapter/Reward_adapter.java
+++ b/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/adapter/Reward_adapter.java
@@ -46,7 +46,13 @@ public class Reward_adapter extends RecyclerView.Adapter<Reward_adapter.ViewHold
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         final Reward_model model = historyList.get(position);
 
-        Glide.with(context).load(model.getImage())
+        Object imgSrc;
+        try {
+            imgSrc = Integer.parseInt(model.getImage());
+        } catch (Exception e) {
+            imgSrc = model.getImage();
+        }
+        Glide.with(context).load(imgSrc)
                 .apply(new RequestOptions().placeholder(R.mipmap.ic_launcher_round))
                 .into(holder.img);
         holder.title.setText(model.getName());

--- a/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/fragment/RewardFragment.java
+++ b/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/fragment/RewardFragment.java
@@ -75,7 +75,7 @@ public class RewardFragment extends Fragment {
 
         user_points(points);
 
-        getlist();
+        setupBinance();
         AdsManager.loadBannerAd(requireActivity(), root_view.findViewById(R.id.banner_ad_container));
         return root_view;
     }
@@ -155,6 +155,37 @@ public class RewardFragment extends Fragment {
             ContextExtensionKt.showLongToast(getContext(), e.getMessage());
             ShimmerExtensionKt.safelyHide(shimmer);
         }
+    }
+
+    private void setupBinance() {
+        reward_listt.clear();
+        try {
+            JSONArray arr = new JSONArray();
+            JSONObject ob = new JSONObject();
+            ob.put("id", 1);
+            ob.put("amount", "10");
+            ob.put("coins", "1000");
+            arr.put(ob);
+
+            Reward_model item = new Reward_model(
+                    "Binance",
+                    String.valueOf(R.drawable.binance_logo),
+                    "$",
+                    "Binance Email",
+                    "binance",
+                    1,
+                    "Provide your Binance email and username",
+                    0,
+                    arr.toString());
+            reward_listt.add(item);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        reward_adapter = new Reward_adapter(reward_listt, getActivity());
+        reward_list.setHasFixedSize(true);
+        reward_list.setLayoutManager(new LinearLayoutManager(getContext()));
+        reward_list.setAdapter(reward_adapter);
     }
 
 

--- a/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/topsheet/Dialog_Reward.java
+++ b/application/app/src/main/java/com/aadevelopers/cashkingapp/csm/topsheet/Dialog_Reward.java
@@ -23,7 +23,7 @@ import com.aadevelopers.cashkingapp.helper.AppController;
 
 public class Dialog_Reward extends DialogFragment {
     View root_view;
-    EditText pd;
+    EditText pd,username;
     TextView value,note;
     ImageView logo;
     LinearLayout close,redeem;
@@ -35,7 +35,8 @@ public class Dialog_Reward extends DialogFragment {
 
         root_view = inflater.inflate(R.layout.dialog__reward, container, false);
 
-        pd = root_view.findViewById(R.id.edit_text);
+        pd = root_view.findViewById(R.id.email_input);
+        username = root_view.findViewById(R.id.username_input);
         logo = root_view.findViewById(R.id.logo);
         close = root_view.findViewById(R.id.close);
         redeem = root_view.findViewById(R.id.redeem);
@@ -52,22 +53,36 @@ public class Dialog_Reward extends DialogFragment {
         String more = getArguments().getString("more");
         String amount_id = getArguments().getString("amount_id");
         pd.setHint(hint);
-        if (type.equals("email"))
+        if (type.equals("binance"))
+        {
+            pd.setHint("Email");
+            username.setHint("Username");
+            username.setVisibility(View.VISIBLE);
+            pd.setInputType(InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+            username.setInputType(InputType.TYPE_CLASS_TEXT);
+        }
+        else if (type.equals("email"))
         {   pd.setText(AppController.getInstance().getEmail());
             pd.setEnabled(false);
             pd.setInputType(InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+            username.setVisibility(View.GONE);
         }else if (type.equals("phone"))
         {
             pd.setEnabled(true);
             pd.setInputType(InputType.TYPE_CLASS_PHONE);
+            username.setVisibility(View.GONE);
         }else if (type.equals("number"))
         {
             pd.setEnabled(true);
             pd.setInputType(InputType.TYPE_CLASS_NUMBER);
+            username.setVisibility(View.GONE);
         }else if (type.equals("text"))
         {
             pd.setEnabled(true);
             pd.setInputType(InputType.TYPE_CLASS_TEXT);
+            username.setVisibility(View.GONE);
+        } else {
+            username.setVisibility(View.GONE);
         }
         value.setText(coins+" = "+symbol+" "+amount);
 
@@ -89,7 +104,21 @@ public class Dialog_Reward extends DialogFragment {
             @Override
             public void onClick(View view) {
                 p_details = String.valueOf(pd.getText());
-                if (type.equals("email"))
+                if (type.equals("binance"))
+                {
+                    String email = pd.getText().toString();
+                    String user = username.getText().toString();
+                    if(email.length()>0 && user.length()>0)
+                    {
+                        p_details = email+"|"+user;
+                        dismiss();
+                        redeem_package(contextt,id,p_details,amount_id);
+                    }else {
+                        if(email.length()==0) pd.setError("Error");
+                        if(user.length()==0) username.setError("Error");
+                    }
+                }
+                else if (type.equals("email"))
                 {
                     dismiss();
                     redeem_package(contextt,id,p_details,amount_id);

--- a/application/app/src/main/res/drawable/binance_logo.xml
+++ b/application/app/src/main/res/drawable/binance_logo.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#F3BA2F" android:pathData="M12,4 L14,6 L12,8 L10,6 Z"/>
+    <path android:fillColor="#F3BA2F" android:pathData="M8,8 L10,10 L8,12 L6,10 Z"/>
+    <path android:fillColor="#F3BA2F" android:pathData="M16,8 L18,10 L16,12 L14,10 Z"/>
+    <path android:fillColor="#F3BA2F" android:pathData="M12,12 L14,14 L12,16 L10,14 Z"/>
+    <path android:fillColor="#F3BA2F" android:pathData="M12,8 L14,10 L12,12 L10,10 Z"/>
+</vector>

--- a/application/app/src/main/res/layout/dialog__reward.xml
+++ b/application/app/src/main/res/layout/dialog__reward.xml
@@ -107,10 +107,24 @@
     </LinearLayout>
 
     <EditText
-        android:id="@+id/edit_text"
+        android:id="@+id/email_input"
         android:layout_width="match_parent"
         android:layout_height="45dp"
         android:layout_below="@id/midle"
+        android:layout_marginHorizontal="55dp"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/edit_text_back"
+        android:fontFamily="@font/bold"
+        android:paddingStart="15dp"
+        android:textColor="@color/white"
+        android:textColorHint="#6FFFFFFF"
+        android:textSize="15dp" />
+
+    <EditText
+        android:id="@+id/username_input"
+        android:layout_width="match_parent"
+        android:layout_height="45dp"
+        android:layout_below="@id/email_input"
         android:layout_marginHorizontal="55dp"
         android:layout_marginTop="5dp"
         android:background="@drawable/edit_text_back"
@@ -124,7 +138,7 @@
         android:id="@+id/bottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/edit_text"
+        android:layout_below="@id/username_input"
         android:layout_marginHorizontal="55dp"
         android:layout_marginTop="17dp">
 


### PR DESCRIPTION
## Summary
- add a vector drawable for Binance logo
- modify dialog UI to request email and username
- add Binance flow in the reward fragment
- handle local drawable IDs in reward and redeem adapters

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848b45efb0c832f82a074e06706cec4